### PR TITLE
Cm/add testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ However far you and your partner get, the application should have, at a minimum,
 - Deployed application to [Heroku](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/00-programming-fundamentals/11-deploying-to-heroku.md)
 - A "look and feel" that will make you and your partner happy!
 - Your application must have controller & model tests written
-  - Your model tests should include tests for validations and any custom methods
+  - Your model tests should include tests for validations, relationships and any custom methods
   - We have provided a set of sample tests that you can use as a starting place for the `Driver` and `Passenger` models.  We have also provided a scaffolding for the `Trip` model.  You should feel free to adapt the tests to meet your design.
   - You will also need to write tests for your controller actions.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ However far you and your partner get, the application should have, at a minimum,
 - [RESTful routing](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/08-rails/mvc-and-restful-routing.md)
 - Deployed application to [Heroku](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/00-programming-fundamentals/11-deploying-to-heroku.md)
 - A "look and feel" that will make you and your partner happy!
+- Your application must have controller & model tests written
+  - Your model tests should include tests for validations and any custom methods
+  - We have provided a set of sample tests that you can use as a starting place for the `Driver` and `Passenger` models.  We have also provided a scaffolding for the `Trip` model.  You should feel free to adapt the tests to meet your design.
+  - You will also need to write tests for your controller actions.
 
 ### Things to Keep in Mind
 
@@ -79,7 +83,7 @@ However far you and your partner get, the application should have, at a minimum,
 
 ### Wireframes
 
-We have provided some wireframes below; they are optional to use for executing layout. However, they should provide guidance for what views and information we instructors are expecting to see and interact with as we grade.
+We have provided some wireframes below; they are optional to use for executing layout. However, they should provide guidance for what views and information we instructors are expecting to see and interact with as we grade.  We also have an [instructor reference version](https://ada-rideshare-demo.herokuapp.com/) of the application running.  You can use this for reference or ideas.
 
 ### Seeding the Database
 

--- a/feedback.md
+++ b/feedback.md
@@ -12,9 +12,11 @@ RESTful routes utilized |
 Table relationships |
 Validation rules for Models |
 Business logic is in the models |
+Tests for validations | 
+Tests for relationships | 
+Tests for custom model methods |
 Database is seeded from the CSV files |
 Trello board is created and utilized in project management |
-Postgres database is used |
 Heroku instance is online |
 The app is styled to create an attractive user interface |
 **Overall** |

--- a/test/controllers/drivers_controller_test.rb
+++ b/test/controllers/drivers_controller_test.rb
@@ -20,7 +20,7 @@ describe DriversController do
   end
 
   describe "new" do
-    #
+    # Your tests go here
   end
 
   describe "create" do

--- a/test/controllers/drivers_controller_test.rb
+++ b/test/controllers/drivers_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+describe DriversController do
+  describe "index" do
+    it "can get index" do
+      # Your code here
+    end
+  end
+
+  describe "show" do
+    # Your tests go here
+  end
+
+  describe "edit" do
+    # Your tests go here
+  end
+
+  describe "update" do
+    # Your tests go here
+  end
+
+  describe "new" do
+    #
+  end
+
+  describe "create" do
+    # Your tests go here
+  end
+
+  describe "destroy" do
+    # Your tests go here
+  end
+end

--- a/test/controllers/homepages_controller_test.rb
+++ b/test/controllers/homepages_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+describe HomepagesController do
+  it "can get the homepage" do
+    get root_path
+
+    must_respond_with :success
+  end
+end

--- a/test/controllers/passengers_controller_test.rb
+++ b/test/controllers/passengers_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+describe PassengersController do
+  describe "index" do
+    # Your tests go here
+  end
+
+  describe "show" do
+    # Your tests go here
+  end
+
+  describe "edit" do
+    # Your tests go here
+  end
+
+  describe "update" do
+    # Your tests go here
+  end
+
+  describe "new" do
+    # Your tests go here
+  end
+
+  describe "create" do
+    # Your tests go here
+  end
+
+  describe "destroy" do
+    # Your tests go here
+  end
+end

--- a/test/controllers/trips_controller_test.rb
+++ b/test/controllers/trips_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+describe TripsController do
+  describe "show" do
+    # Your tests go here
+  end
+
+  describe "edit" do
+    # Your tests go here
+  end
+
+  describe "update" do
+    # Your tests go here
+  end
+
+  describe "create" do
+    # Your tests go here
+  end
+
+  describe "destroy" do
+    # Your tests go here
+  end
+end

--- a/test/models/driver_test.rb
+++ b/test/models/driver_test.rb
@@ -22,8 +22,10 @@ describe Driver do
 
   describe "relationships" do
     it "can have many trips" do
+      # Arrange
       driver = Driver.first
 
+      # Assert
       expect(driver.trips.count).must_be :>=, 0
       driver.trips.each do |trip|
         expect(trip).must_be_instance_of Trip

--- a/test/models/driver_test.rb
+++ b/test/models/driver_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+describe Driver do
+  let (:new_driver) {
+    Driver.new(name: "Kari", vin: "123", active: true,
+               car_make: "Cherry", car_model: "DR5")
+  }
+  it "can be instantiated" do
+    # Assert
+    expect(new_driver.valid?).must_equal true
+  end
+
+  it "will have the required fields" do
+    # Arrange
+    driver = Driver.first
+    [:name, :vin, :active, :car_make, :car_model].each do |field|
+
+      # Assert
+      expect(driver).must_respond_to field
+    end
+  end
+
+  describe "relationships" do
+    it "can have many trips" do
+      driver = Driver.first
+
+      expect(driver.trips.count).must_be :>=, 0
+      driver.trips.each do |trip|
+        expect(trip).must_be_instance_of Trip
+      end
+    end
+  end
+
+  describe "validations" do
+    it "must have a name" do
+      # Arrange
+      new_driver.name = nil
+
+      # Assert
+      expect(new_driver.valid?).must_equal false
+      expect(new_driver.errors.messages).must_include :name
+      expect(new_driver.errors.messages[:name]).must_equal ["can't be blank"]
+    end
+
+    it "must have a VIN number" do
+      # Arrange
+      new_driver.vin = nil
+
+      # Assert
+      expect(new_driver.valid?).must_equal false
+      expect(new_driver.errors.messages).must_include :vin
+      expect(new_driver.errors.messages[:vin]).must_equal ["can't be blank"]
+    end
+  end
+
+  # Tests for methods you create should go here
+  describe "custom methods" do
+    describe "average rating" do
+      # Your code here
+    end
+
+    describe "total earnings" do
+      # Your code here
+    end
+
+    describe "can go online" do
+      # Your code here
+    end
+
+    describe "can go offline" do
+      # Your code here
+    end
+
+    # You may have additional methods to test
+  end
+end

--- a/test/models/passenger_test.rb
+++ b/test/models/passenger_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+describe Passenger do
+  let (:new_passenger) {
+    Passenger.new(name: "Kari", phone_number: "111-111-1211")
+  }
+  it "can be instantiated" do
+    # Assert
+    expect(new_passenger.valid?).must_equal true
+  end
+
+  it "will have the required fields" do
+    # Arrange
+    passenger = Passenger.first
+    [:name, :phone_number].each do |field|
+
+      # Assert
+      expect(passenger).must_respond_to field
+    end
+  end
+
+  describe "relationships" do
+    it "can have many trips" do
+      passenger = Passenger.first
+
+      expect(passenger.trips.count).must_be :>, 0
+      passenger.trips.each do |trip|
+        expect(trip).must_be_instance_of Trip
+      end
+    end
+  end
+
+  describe "validations" do
+    it "must have a name" do
+      # Arrange
+      new_passenger.name = nil
+
+      # Assert
+      expect(new_passenger.valid?).must_equal false
+      expect(new_passenger.errors.messages).must_include :name
+      expect(new_passenger.errors.messages[:name]).must_equal ["can't be blank"]
+    end
+
+    it "must have a phone number" do
+      # Arrange
+      new_passenger.phone_number = nil
+
+      # Assert
+      expect(new_passenger.valid?).must_equal false
+      expect(new_passenger.errors.messages).must_include :new_passenger
+      expect(new_passenger.errors.messages[:new_passenger]).must_equal ["can't be blank"]
+    end
+  end
+
+  # Tests for methods you create should go here
+  describe "custom methods" do
+    describe "request a ride" do
+      # Your code here
+    end
+
+    describe "complete trip" do
+      # Your code here
+    end
+    # You may have additional methods to test here
+  end
+end

--- a/test/models/passenger_test.rb
+++ b/test/models/passenger_test.rb
@@ -21,8 +21,10 @@ describe Passenger do
 
   describe "relationships" do
     it "can have many trips" do
+      # Arrange
       passenger = Passenger.first
 
+      # Assert
       expect(passenger.trips.count).must_be :>, 0
       passenger.trips.each do |trip|
         expect(trip).must_be_instance_of Trip

--- a/test/models/trip_test.rb
+++ b/test/models/trip_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+describe Trip do
+  it "can be instantiated" do
+    # Your code here
+  end
+
+  it "will have the required fields" do
+    # Your code here
+  end
+
+  describe "relationships" do
+    # Your tests go here
+  end
+
+  describe "validations" do
+    # Your tests go here
+  end
+
+  # Tests for methods you create should go here
+  describe "custom methods" do
+    # Your tests here
+  end
+end


### PR DESCRIPTION
# Rideshare-Rails

I added a test scaffold for Rideshare Rails with model and controller tests.  The Driver and Passenger models have many of the tests written with Trip leaving a scaffold for students to fill in tests for.  Students will need to write tests for custom methods.  I've also updated the README to mention testing, and added a link to my running demo of Ride-Share-Rails.  The updated demo is Charles old version updated to a newer version of Rails, and some minor changes and bug fixes.  

Todo:

- I need another pass to verify my CSS matches the BEM naming convention on the demo app, just for consistency with MediaRanker and other demo apps.  
- I need to add flash notices to the demo site.